### PR TITLE
Fix broken LinkedIn link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Note: Please check out my [GitHub Copilot All-In-One (AIO) course ](https://gith
 ## Tim's contact information
 
 - [Tim Warner](mailto:timothywarner316@gmail.com)
-- [LinkedIn](https://www.linkedinn.com/in/timothywarner/)
+- [LinkedIn](https://www.linkedin.com/in/timothywarner/)
 - [Website](https://techtrainertim.com)
 - [Azure OpenAI Training Blog](https://azureopenai.blog)
 - [Bluesky](https://bsky.app/profile/techtrainertim.bsky.social)


### PR DESCRIPTION
Related to #38

Corrects the broken LinkedIn hyperlink in the `README.md` file.

- Updates the LinkedIn URL from "https://www.linkedinn.com/in/timothywarner/" to the correct "https://www.linkedin.com/in/timothywarner/" to ensure the link functions properly and directs users to the intended LinkedIn profile.


---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/timothywarner/chatgptclass/issues/38?shareId=74984b1e-223b-4587-9ef9-6d1accc8c4b6).